### PR TITLE
Oracle

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -44,11 +44,11 @@ function installer_db_now() {
 switch( $GLOBALS['g_db_type'] ) {
 	case 'oci8':
 		$t_notnull = "";
-		$t_timestamp = 'timestamp' . installer_db_now();
+		$t_timestamp = "timestamp" . installer_db_now();
 		break;
 	default:
 		$t_notnull = 'NOTNULL';
-		$t_timestamp = installer_db_now();
+		$t_timestamp = "'" . installer_db_now() . "'";
 		break;
 }
 
@@ -356,7 +356,7 @@ $upgrade[] = Array('CreateIndexSQL',Array('idx_access',db_get_table('mantis_user
 
 $upgrade[] = Array('InsertData', Array( db_get_table('mantis_user_table'),
 	"(username, realname, email, password, date_created, last_visit, enabled, protected, access_level, login_count, lost_password_request_count, failed_login_count, cookie_string) VALUES
-		('administrator', '', 'root@localhost', '63a9f0ea7bb98050796b649e85481845', '" . $t_timestamp . "', '" . $t_timestamp . "', '1', '0', 90, 3, 0, 0, '" .
+		('administrator', '', 'root@localhost', '63a9f0ea7bb98050796b649e85481845', " . $t_timestamp . ", " . $t_timestamp . ", '1', '0', 90, 3, 0, 0, '" .
 			md5( mt_rand( 0, mt_getrandmax() ) + mt_rand( 0, mt_getrandmax() ) ) . md5( time() ) . "')" ) );
 
 $upgrade[] = Array('AlterColumnSQL', Array( db_get_table( 'mantis_bug_history_table' ), "old_value C(255) $t_notnull" ) );

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -1047,8 +1047,21 @@ function db_oracle_order_binds_sequentially( $p_query ) {
  */
 function db_oracle_adapt_query_syntax( $p_query , &$arr_parms = null ) {
 	# Remove "AS" keyword, because not supported with table aliasing
-	#@@@ Could potentially cause issues if ' AS ' is contained within a string ?
-	$p_query = preg_replace( '/ AS /im' , ' ' , $p_query );
+	$t_is_odd = true;
+	$t_query = '';
+	# Divide statement to skip processing string literals
+	$t_p_query_arr = explode( '\'' , $p_query );
+	foreach( $t_p_query_arr as $t_p_query_part ) {
+		if( $t_query != '' )
+			$t_query .= '\'';
+		if( $t_is_odd ) {
+			$t_query .= preg_replace( '/ AS /im' , ' ' , $t_p_query_part );
+		} else {
+			$t_query .= $t_p_query_part;
+			$t_is_odd = true;
+		}
+	}
+	$p_query = $t_query;
 
 	# Remove null bind variables in insert statements for default values support
 	if( is_array ( $arr_parms ) ) {


### PR DESCRIPTION
Fixed datetime literal format and bug with removing 'AS' from string literals

Tests passed with MySQL and Oracle.
Oracle installation reqires only changing:
1. $g_db_table_suffix: Just as planned, to reduce object name length
2. $g_db_type: because of config_get_global( 'db_type' ) returns 'mysql' on installation stage
