### PR TITLE
Prompt an error message when a library is not found, e.g. submodules are...

### DIFF
--- a/core.php
+++ b/core.php
@@ -123,7 +123,14 @@ function require_lib( $p_library_name ) {
 	global $g_library_path;
 	if ( !isset( $g_libraries_included[$p_library_name] ) ) {
 		$t_existing_globals = get_defined_vars();
-		require_once( $g_library_path . $p_library_name );
+
+		$t_library_file_path = $g_library_path . $p_library_name;
+		if ( !file_exists( $t_library_file_path ) ) {
+			echo "File '$t_library_file_path' doesn't exist.";
+			exit;
+		}
+
+		require_once( $t_library_file_path );
 		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_existing_globals' => 0, 't_new_globals' => 0 ) );
 		foreach ( $t_new_globals as $t_global_name => $t_global_value ) {
 			global $$t_global_name;


### PR DESCRIPTION
... empty.  This is better than an empty web page.
