### PR TITLE
Improve error handling for command-line scripts

### DIFF
--- a/core/error_api.php
+++ b/core/error_api.php
@@ -110,14 +110,16 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, $p_context ) {
 	}
 
 	# build an appropriate error string
+	$t_error_description = "'$p_error' in '$p_file' line $p_line";
 	switch( $p_type ) {
 		case E_WARNING:
 			$t_error_type = 'SYSTEM WARNING';
-			$t_error_description = "'$p_error' in '$p_file' line $p_line";
 			break;
 		case E_NOTICE:
 			$t_error_type = 'SYSTEM NOTICE';
-			$t_error_description = "'$p_error' in '$p_file' line $p_line";
+			break;
+		case E_DEPRECATED:
+			$t_error_type = 'DEPRECATED';
 			break;
 		case E_USER_ERROR:
 			$t_error_type = "APPLICATION ERROR #$p_error";


### PR DESCRIPTION
Commit 461a7115d37de79e4875b651edd10fd556a533c3 added CLI-specific handling for errors to display messages without HTML formatting.

This introduced a regression, causing scripts to abort even for non-critical errors that would normally allow execution to continue (such as PHP warnings as well as system and deprecated notices). Furthermore, in that case the exit code is 0, so the caller is not able to detect the failure to take appropriate action.

This improves how CLI errors are managed, making it similar to regular MantisBT error handling, i.e.
- honor $g_display_errors settings 
  - abort only for DISPLAY_ERROR_HALT (in that case exit code is 1)
  - don't print message if DISPLAY_ERROR_NONE
- handle E_DEPRECATED error type
- improve message for unhandled error types
- print a debug backtrace when show_detailed_errors == ON

Fixes #17270
