### PR TITLE
Evaluate db_param as a callback for replacement

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -385,11 +385,12 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 	$p_query = strtr($p_query, array(
 							'{' => $s_prefix,
 							'}' => $s_suffix,
-							'%s' => db_param(),
-							'%d' => db_param(),
-							'%b' => db_param(),
-							'%l' => db_param(),
 							) );
+	$p_query = preg_replace_callback(
+							array( "/%s/", "/%d/", "/%b/", "/%l/"),
+							"db_param",
+							$p_query
+							);
 
 	if( db_is_oracle() ) {
 		$p_query = db_oracle_adapt_query_syntax( $p_query, $p_arr_parms );


### PR DESCRIPTION
Fix the shift of param count due to evaluating
the db_param() function as part of argument of
string replace